### PR TITLE
Added support for remote downstream drone servers

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 // configure and customzie the git clone behavior.
 type Params struct {
 	Repos []string `json:"repositories"`
+	Server string `json:"server"`
 	Token string   `json:"token"`
 	Fork  bool     `json:"fork"`
 }
@@ -31,8 +32,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if v.Server == "" {
+		v.Server = s.Link
+	}
+
+
 	// create the drone client
-	client := drone.NewClientToken(s.Link, v.Token)
+	client := drone.NewClientToken(v.Server, v.Token)
 
 	for _, entry := range v.Repos {
 


### PR DESCRIPTION
Added support for remote downstream drone servers using a new Server: parameter. Now the downstream plugin can be called like:

```
notify:
  trigger:
    server: "http://drone.octocat.com"
    repositories: [ "foo/bar" ]
```

And it will trigger a build in the remote drone server. Thanks to @bradrydzewski for the indications !