### PR TITLE
Added ability to wait before triggering a downstream build if current status is "running"

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 		},
 		cli.DurationFlag{
 			Name:   "timeout",
-                        Value:  time.Duration(60)*time.Second,
+			Value:  time.Duration(60)*time.Second,
 			Usage:  "How long to wait on any currently running builds",
 			EnvVar: "PLUGIN_WAIT_TIMEOUT",
 		},

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
-	"os"
-	"time"
 )
 
 var build = "0" // build number set at compile-time

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-
+	"time"
 	"github.com/Sirupsen/logrus"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
@@ -38,6 +38,17 @@ func main() {
 			Usage:  "Trigger a new build for a repository",
 			EnvVar: "PLUGIN_FORK",
 		},
+		cli.BoolFlag{
+			Name:   "wait",
+			Usage:  "Wait for any currently running builds to finish",
+			EnvVar: "PLUGIN_WAIT",
+		},
+		cli.DurationFlag{
+			Name:   "timeout",
+                        Value:  time.Duration(60)*time.Second,
+			Usage:  "How long to wait on any currently running builds",
+			EnvVar: "PLUGIN_WAIT_TIMEOUT",
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -59,6 +70,8 @@ func run(c *cli.Context) error {
 		Server: c.String("server"),
 		Token:  c.String("token"),
 		Fork:   c.Bool("fork"),
+		Wait:   c.Bool("wait"),
+		Timeout:   c.Duration("timeout"),
 	}
 
 	return plugin.Exec()

--- a/main.go
+++ b/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"time"
 	"github.com/Sirupsen/logrus"
 	"github.com/joho/godotenv"
 	"github.com/urfave/cli"
+	"os"
+	"time"
 )
 
 var build = "0" // build number set at compile-time
@@ -45,7 +45,7 @@ func main() {
 		},
 		cli.DurationFlag{
 			Name:   "timeout",
-			Value:  time.Duration(60)*time.Second,
+			Value:  time.Duration(60) * time.Second,
 			Usage:  "How long to wait on any currently running builds",
 			EnvVar: "PLUGIN_WAIT_TIMEOUT",
 		},
@@ -66,12 +66,12 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Repos:  c.StringSlice("repositories"),
-		Server: c.String("server"),
-		Token:  c.String("token"),
-		Fork:   c.Bool("fork"),
-		Wait:   c.Bool("wait"),
-		Timeout:   c.Duration("timeout"),
+		Repos:   c.StringSlice("repositories"),
+		Server:  c.String("server"),
+		Token:   c.String("token"),
+		Fork:    c.Bool("fork"),
+		Wait:    c.Bool("wait"),
+		Timeout: c.Duration("timeout"),
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/drone/drone-go/drone"
 	"strings"
 	"time"
+
+	"github.com/drone/drone-go/drone"
 )
 
 // Plugin defines the Downstream plugin parameters.
@@ -30,13 +31,15 @@ func (p *Plugin) Exec() error {
 	client := drone.NewClientToken(p.Server, p.Token)
 
 	for _, entry := range p.Repos {
+
+		// parses the repository name in owner/name@branch format
 		owner, name, branch := parseRepoBranch(entry)
 		if len(owner) == 0 || len(name) == 0 {
 			return fmt.Errorf("Error: unable to parse repository name %s.\n", entry)
 		}
 
 		timeout := time.After(p.Timeout)
-		tick := time.Tick(500 * time.Millisecond)
+		tick := time.Tick(1 * time.Second)
 
 		// Keep trying until we're timed out, successful or got an error
 		// Tagged with "I" due to break nested in select
@@ -72,7 +75,7 @@ func (p *Plugin) Exec() error {
 						break I
 					}
 				} else if p.Wait == true {
-					fmt.Printf("Waiting on running build for: " + entry + "\n")
+					fmt.Printf("BuildLast for repository: %s, returned build number: %v with a status of %s. Will retry for %v.\n", entry, build.Number, build.Status, p.Timeout)
 				}
 			}
 		}

--- a/plugin.go
+++ b/plugin.go
@@ -26,7 +26,7 @@ func (p *Plugin) Exec() error {
 	if len(p.Server) == 0 {
 		return fmt.Errorf("Error: you must provide your Drone server.")
 	}
-	// parses the repository name in owner/name@branch format 
+
 	client := drone.NewClientToken(p.Server, p.Token)
 
 	for _, entry := range p.Repos {

--- a/plugin.go
+++ b/plugin.go
@@ -26,7 +26,7 @@ func (p *Plugin) Exec() error {
 	if len(p.Server) == 0 {
 		return fmt.Errorf("Error: you must provide your Drone server.")
 	}
-
+	// parses the repository name in owner/name@branch format 
 	client := drone.NewClientToken(p.Server, p.Token)
 
 	for _, entry := range p.Repos {

--- a/plugin.go
+++ b/plugin.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
-
+	"time"
 	"github.com/drone/drone-go/drone"
 )
 
@@ -13,11 +13,12 @@ type Plugin struct {
 	Server string
 	Token  string
 	Fork   bool
+	Wait   bool
+	Timeout  time.Duration
 }
 
 // Exec runs the plugin
 func (p *Plugin) Exec() error {
-
 	if len(p.Token) == 0 {
 		return fmt.Errorf("Error: you must provide your Drone access token.")
 	}
@@ -29,46 +30,56 @@ func (p *Plugin) Exec() error {
 	client := drone.NewClientToken(p.Server, p.Token)
 
 	for _, entry := range p.Repos {
-
-		// parses the repository name in owner/name@branch format
-		owner, name, branch := parseRepoBranch(entry)
+	        owner, name, branch := parseRepoBranch(entry)
 		if len(owner) == 0 || len(name) == 0 {
 			return fmt.Errorf("Error: unable to parse repository name %s.\n", entry)
 		}
-		if p.Fork {
-			// get the latest build for the specified repository
-			build, err := client.BuildLast(owner, name, branch)
-			if err != nil {
-				return fmt.Errorf("Error: unable to get latest build for %s.\n", entry)
-			}
-			// start a new  build
-			_, err = client.BuildFork(owner, name, build.Number)
-			if err != nil {
-				return fmt.Errorf("Error: unable to trigger a new build for %s.\n", entry)
-			}
 
-			fmt.Printf("Starting new build %d for %s\n", build.Number, entry)
-
-		} else {
-			// get the latest build for the specified repository
-			build, err := client.BuildLast(owner, name, branch)
-			if err != nil {
-				return fmt.Errorf("Error: unable to get latest build for %s.\n", entry)
+		timeout := time.After(p.Timeout)
+		tick := time.Tick(500 * time.Millisecond)
+	
+		// Keep trying until we're timed out, successful or got an error
+		// Tagged with "I" due to break nested in select
+                I:
+		for {
+			select {
+			// Got a timeout! fail with a timeout error
+			case <-timeout:
+				return fmt.Errorf("Error: timed out waiting on a build for %s.\n", entry)
+			// Got a tick, we should check on the build status
+			case <-tick:
+				// get the latest build for the specified repository
+				build, err := client.BuildLast(owner, name, branch)
+				if err != nil {
+					return fmt.Errorf("Error: unable to get latest build for %s.\n", entry)
+				}
+				if (build.Status != drone.StatusRunning || p.Wait == false) {
+					if p.Fork {
+					      	// start a new  build
+						_, err = client.BuildFork(owner, name, build.Number)
+						if err != nil {
+							return fmt.Errorf("Error: unable to trigger a new build for %s.\n", entry)
+						}
+						fmt.Printf("Starting new build %d for %s.\n", build.Number, entry)
+                                                break I;
+					} else {
+						// rebuild the latest build
+						_, err = client.BuildStart(owner, name, build.Number)
+						if err != nil {
+							return fmt.Errorf("Error: unable to trigger build for %s.\n", entry)
+						}
+						fmt.Printf("Restarting build %d for %s\n", build.Number, entry)
+                                                break I;
+					}
+				} else if p.Wait == true {
+					fmt.Printf("Waiting on running build for: " + entry + "\n")
+				}
 			}
-
-			// rebuild the latest build
-			_, err = client.BuildStart(owner, name, build.Number)
-			if err != nil {
-				return fmt.Errorf("Error: unable to trigger build for %s.\n", entry)
-			}
-
-			fmt.Printf("Restarting build %d for %s\n", build.Number, entry)
 		}
 	}
-
 	return nil
 }
-
+	
 func parseRepoBranch(repo string) (string, string, string) {
 	var (
 		owner  string
@@ -89,3 +100,4 @@ func parseRepoBranch(repo string) (string, string, string) {
 	}
 	return owner, name, branch
 }
+


### PR DESCRIPTION
I'm not sure if you'd like to include this upstream but it has proved quite useful for me when dealing with downstream projects that have more than one upstream dependency that could trigger a build.