### PR TITLE
32 - docker tag management

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,11 @@ pipeline:
     image: plugins/docker:17.05
     pull: true
     repo: plugins/downstream
-    tags: [ latest, 1.0.0, 1.0, 1 ]
+    tags:
+      - latest
+      - 1.0
+      - 1
+      - 1.0.${DRONE_BUILD_NUMBER}
     secrets: [ docker_username, docker_password ]
     dockerfile: Dockerfile
     when:


### PR DESCRIPTION
- docker tag management with updated build number.
- remove tag `1.0.0`, which is replaced with `1.0.<build_number>`