### PR TITLE
Support for build params

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,11 @@ func main() {
 			Usage:  "List of params (key=value or file paths of params) to pass to triggered builds",
 			EnvVar: "PLUGIN_PARAMS",
 		},
+		cli.StringSliceFlag{
+			Name:   "params-from-env",
+			Usage:  "List of environment variables to pass to triggered builds",
+			EnvVar: "PLUGIN_PARAMS_FROM_ENV",
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -72,13 +77,14 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Repos:   c.StringSlice("repositories"),
-		Server:  c.String("server"),
-		Token:   c.String("token"),
-		Fork:    c.Bool("fork"),
-		Wait:    c.Bool("wait"),
-		Timeout: c.Duration("timeout"),
-		Params:  c.StringSlice("params"),
+		Repos:     c.StringSlice("repositories"),
+		Server:    c.String("server"),
+		Token:     c.String("token"),
+		Fork:      c.Bool("fork"),
+		Wait:      c.Bool("wait"),
+		Timeout:   c.Duration("timeout"),
+		Params:    c.StringSlice("params"),
+		ParamsEnv: c.StringSlice("params-from-env"),
 	}
 
 	return plugin.Exec()

--- a/main.go
+++ b/main.go
@@ -50,6 +50,11 @@ func main() {
 			Usage:  "How long to wait on any currently running builds",
 			EnvVar: "PLUGIN_WAIT_TIMEOUT",
 		},
+		cli.StringSliceFlag{
+			Name:   "params",
+			Usage:  "List of params (key=value or file paths of params) to pass to triggered builds",
+			EnvVar: "PLUGIN_PARAMS",
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -73,6 +78,7 @@ func run(c *cli.Context) error {
 		Fork:    c.Bool("fork"),
 		Wait:    c.Bool("wait"),
 		Timeout: c.Duration("timeout"),
+		Params:  c.StringSlice("params"),
 	}
 
 	return plugin.Exec()

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -27,6 +28,64 @@ func Test_parseRepoBranch(t *testing.T) {
 		}
 		if branch != test.Branch {
 			t.Errorf("wanted repository branch %s, got %s", test.Branch, branch)
+		}
+	}
+}
+
+func Test_parseParams_invalid(t *testing.T) {
+	out, err := parseParams([]string{"invalid"})
+	if err == nil {
+		t.Errorf("expected error, got %v", out)
+	}
+}
+
+func Test_parseParams(t *testing.T) {
+	var tests = []struct {
+		Input  []string
+		Output map[string]string
+	}{
+		{[]string{}, map[string]string{}},
+		{
+			[]string{"where=far", "who=you"},
+			map[string]string{"where": "far", "who": "you"},
+		},
+		{
+			[]string{"where=very=far"},
+			map[string]string{"where": "very=far"}},
+		{
+			[]string{"test_params.env"},
+			map[string]string{
+				"SOME_VAR": "someval",
+				"FOO":      "BAR",
+				"BAR":      "BAZ",
+				"foo":      "bar",
+				"bar":      "baz",
+			},
+		},
+		{
+			[]string{"test_params.env", "where=far", "who=you"},
+			map[string]string{
+				"SOME_VAR": "someval",
+				"FOO":      "BAR",
+				"BAR":      "BAZ",
+				"foo":      "bar",
+				"bar":      "baz",
+				"where":    "far",
+				"who":      "you",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		out, err := parseParams(test.Input)
+		if err != nil {
+			t.Errorf("unable to parse params: %s", err)
+
+			break
+		}
+
+		if !reflect.DeepEqual(out, test.Output) {
+			t.Errorf("wanted params %+v, got %+v", test.Output, out)
 		}
 	}
 }

--- a/plugin.go
+++ b/plugin.go
@@ -89,8 +89,8 @@ func (p *Plugin) Exec() error {
 						fmt.Printf("Starting new build %d for %s.\n", build.Number, entry)
 						if len(params) > 0 {
 							fmt.Println("  with params:")
-							for _, k := range params {
-								fmt.Printf("  - %s: %s\n", k, params[k])
+							for k, v := range params {
+								fmt.Printf("  - %s: %s\n", k, v)
 							}
 						}
 						break I
@@ -106,8 +106,8 @@ func (p *Plugin) Exec() error {
 						fmt.Printf("Restarting build %d for %s\n", build.Number, entry)
 						if len(params) > 0 {
 							fmt.Println("  with params:")
-							for _, k := range params {
-								fmt.Printf("  - %s: %s\n", k, params[k])
+							for k, v := range params {
+								fmt.Printf("  - %s: %s\n", k, v)
 							}
 						}
 						break I

--- a/plugin.go
+++ b/plugin.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/drone/drone-go/drone"
+	"github.com/joho/godotenv"
+	"golang.org/x/oauth2"
 )
 
 // Plugin defines the Downstream plugin parameters.
@@ -16,6 +19,7 @@ type Plugin struct {
 	Fork    bool
 	Wait    bool
 	Timeout time.Duration
+	Params  []string
 }
 
 // Exec runs the plugin
@@ -28,7 +32,19 @@ func (p *Plugin) Exec() error {
 		return fmt.Errorf("Error: you must provide your Drone server.")
 	}
 
-	client := drone.NewClientToken(p.Server, p.Token)
+	params, err := parseParams(p.Params)
+	if err != nil {
+		return fmt.Errorf("Error: unable to parse params: %s.\n", err)
+	}
+
+	config := new(oauth2.Config)
+	auth := config.Client(
+		oauth2.NoContext,
+		&oauth2.Token{
+			AccessToken: p.Token,
+		},
+	)
+	client := drone.NewClient(p.Server, auth)
 
 	for _, entry := range p.Repos {
 
@@ -63,7 +79,7 @@ func (p *Plugin) Exec() error {
 				if (build.Status != drone.StatusRunning && build.Status != drone.StatusPending) || p.Wait == false {
 					if p.Fork {
 						// start a new  build
-						_, err = client.BuildFork(owner, name, build.Number)
+						_, err = client.BuildFork(owner, name, build.Number, params)
 						if err != nil {
 							if waiting {
 								continue
@@ -71,10 +87,16 @@ func (p *Plugin) Exec() error {
 							return fmt.Errorf("Error: unable to trigger a new build for %s.\n", entry)
 						}
 						fmt.Printf("Starting new build %d for %s.\n", build.Number, entry)
+						if len(params) > 0 {
+							fmt.Println("  with params:")
+							for _, k := range params {
+								fmt.Printf("  - %s: %s\n", k, params[k])
+							}
+						}
 						break I
 					} else {
 						// rebuild the latest build
-						_, err = client.BuildStart(owner, name, build.Number)
+						_, err = client.BuildStart(owner, name, build.Number, params)
 						if err != nil {
 							if waiting {
 								continue
@@ -82,6 +104,12 @@ func (p *Plugin) Exec() error {
 							return fmt.Errorf("Error: unable to trigger build for %s.\n", entry)
 						}
 						fmt.Printf("Restarting build %d for %s\n", build.Number, entry)
+						if len(params) > 0 {
+							fmt.Println("  with params:")
+							for _, k := range params {
+								fmt.Printf("  - %s: %s\n", k, params[k])
+							}
+						}
 						break I
 					}
 				} else if p.Wait == true {
@@ -113,4 +141,30 @@ func parseRepoBranch(repo string) (string, string, string) {
 		name = parts[1]
 	}
 	return owner, name, branch
+}
+
+func parseParams(paramList []string) (map[string]string, error) {
+	params := make(map[string]string)
+	for _, p := range paramList {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) == 2 {
+			params[parts[0]] = parts[1]
+		} else if _, err := os.Stat(parts[0]); os.IsNotExist(err) {
+			return nil, fmt.Errorf(
+				"invalid param '%s'; must be KEY=VALUE or file path",
+				parts[0],
+			)
+		} else {
+			fileParams, err := godotenv.Read(parts[0])
+			if err != nil {
+				return nil, err
+			}
+
+			for k, v := range fileParams {
+				params[k] = v
+			}
+		}
+	}
+
+	return params, nil
 }

--- a/test_params.env
+++ b/test_params.env
@@ -1,0 +1,10 @@
+# from https://github.com/joho/godotenv#usage
+
+# I am a comment and that is OK
+SOME_VAR=someval
+FOO=BAR # comments at line end are OK too
+export BAR=BAZ
+
+# Or finally you can do YAML(ish) style
+foo: bar
+bar: baz

--- a/vendor/github.com/drone/drone-go/drone/client.go
+++ b/vendor/github.com/drone/drone-go/drone/client.go
@@ -2,75 +2,105 @@ package drone
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-
-	"golang.org/x/oauth2"
+	"strconv"
 )
 
 const (
-	pathSelf    = "%s/api/user"
-	pathFeed    = "%s/api/user/feed"
-	pathRepos   = "%s/api/user/repos"
-	pathRepo    = "%s/api/repos/%s/%s"
-	pathBuilds  = "%s/api/repos/%s/%s/builds"
-	pathBuild   = "%s/api/repos/%s/%s/builds/%v"
-	pathJob     = "%s/api/repos/%s/%s/builds/%d/%d"
-	pathLog     = "%s/api/repos/%s/%s/logs/%d/%d"
-	pathSign    = "%s/api/repos/%s/%s/sign"
-	pathSecrets = "%s/api/repos/%s/%s/secrets"
-	pathSecret  = "%s/api/repos/%s/%s/secrets/%s"
-	pathUsers   = "%s/api/users"
-	pathUser    = "%s/api/users/%s"
-	pathAgent   = "%s/api/agents"
-	pathQueue   = "%s/api/builds"
+	pathSelf           = "%s/api/user"
+	pathFeed           = "%s/api/user/feed"
+	pathRepos          = "%s/api/user/repos"
+	pathRepo           = "%s/api/repos/%s/%s"
+	pathRepoMove       = "%s/api/repos/%s/%s/move?to=%s"
+	pathChown          = "%s/api/repos/%s/%s/chown"
+	pathRepair         = "%s/api/repos/%s/%s/repair"
+	pathBuilds         = "%s/api/repos/%s/%s/builds"
+	pathBuild          = "%s/api/repos/%s/%s/builds/%v"
+	pathApprove        = "%s/api/repos/%s/%s/builds/%d/approve"
+	pathDecline        = "%s/api/repos/%s/%s/builds/%d/decline"
+	pathJob            = "%s/api/repos/%s/%s/builds/%d/%d"
+	pathLog            = "%s/api/repos/%s/%s/logs/%d/%d"
+	pathRepoSecrets    = "%s/api/repos/%s/%s/secrets"
+	pathRepoSecret     = "%s/api/repos/%s/%s/secrets/%s"
+	pathRepoRegistries = "%s/api/repos/%s/%s/registry"
+	pathRepoRegistry   = "%s/api/repos/%s/%s/registry/%s"
+	pathUsers          = "%s/api/users"
+	pathUser           = "%s/api/users/%s"
+	pathBuildQueue     = "%s/api/builds"
 )
 
 type client struct {
 	client *http.Client
-	base   string // base url
+	addr   string
 }
 
-// NewClient returns a client at the specified url.
-func NewClient(uri string) Client {
+// // Options provides a list of client options.
+// type Options struct {
+// 	token string
+// 	proxy string
+// 	pool  *x509.CertPool
+// 	conf  *tls.Config
+// 	skip  bool
+// }
+//
+// // Option defines client options.
+// type Option func(opts *Options)
+//
+// // WithToken returns an option to set the token.
+// func WithToken(token string) Option {
+// 	return func(opts *Options) {
+// 		opts.token = token
+// 	}
+// }
+//
+// // WithTLS returns an option to use custom tls configuration.
+// func WithTLS(conf *tls.Config) Option {
+// 	return func(opts *Options) {
+// 		opts.conf = conf
+// 	}
+// }
+//
+// // WithSocks returns a client option to provide a socks5 proxy.
+// func WithSocks(proxy string) Option {
+// 	return func(opts *Options) {
+// 		opts.proxy = proxy
+// 	}
+// }
+//
+// // WithSkipVerify returns a client option to skip ssl verification.
+// func WithSkipVerify(skip bool) Option {
+// 	return func(opts *Options) {
+// 		opts.skip = skip
+// 	}
+// }
+//
+// // WithCertPool returns a client option to provide a custom cert pool.
+// func WithCertPool(pool *x509.CertPool) Option {
+// 	return func(opts *Options) {
+// 		opts.pool = pool
+// 	}
+// }
+
+// New returns a client at the specified url.
+func New(uri string) Client {
 	return &client{http.DefaultClient, uri}
 }
 
-// NewClientToken returns a client at the specified url that
-// authenticates all outbound requests with the given token.
-func NewClientToken(uri, token string) Client {
-	config := new(oauth2.Config)
-	auther := config.Client(oauth2.NoContext, &oauth2.Token{AccessToken: token})
-	return &client{auther, uri}
-}
-
-// NewClientTokenTLS returns a client at the specified url that
-// authenticates all outbound requests with the given token and
-// tls.Config if provided.
-func NewClientTokenTLS(uri, token string, c *tls.Config) Client {
-	config := new(oauth2.Config)
-	auther := config.Client(oauth2.NoContext, &oauth2.Token{AccessToken: token})
-	if c != nil {
-		auther.Transport.(*oauth2.Transport).Base = &http.Transport{TLSClientConfig: c}
-	}
-	return &client{auther, uri}
-}
-
-// SetClient sets the default http client. This should be used in conjunction
-// with golang.org/x/oauth2 to authenticate requests to the Drone server.
-func (c *client) SetClient(client *http.Client) {
-	c.client = client
+// NewClient returns a client at the specified url.
+func NewClient(uri string, cli *http.Client) Client {
+	return &client{cli, uri}
 }
 
 // Self returns the currently authenticated user.
 func (c *client) Self() (*User, error) {
 	out := new(User)
-	uri := fmt.Sprintf(pathSelf, c.base)
+	uri := fmt.Sprintf(pathSelf, c.addr)
 	err := c.get(uri, out)
 	return out, err
 }
@@ -78,7 +108,7 @@ func (c *client) Self() (*User, error) {
 // User returns a user by login.
 func (c *client) User(login string) (*User, error) {
 	out := new(User)
-	uri := fmt.Sprintf(pathUser, c.base, login)
+	uri := fmt.Sprintf(pathUser, c.addr, login)
 	err := c.get(uri, out)
 	return out, err
 }
@@ -86,7 +116,7 @@ func (c *client) User(login string) (*User, error) {
 // UserList returns a list of all registered users.
 func (c *client) UserList() ([]*User, error) {
 	var out []*User
-	uri := fmt.Sprintf(pathUsers, c.base)
+	uri := fmt.Sprintf(pathUsers, c.addr)
 	err := c.get(uri, &out)
 	return out, err
 }
@@ -94,7 +124,7 @@ func (c *client) UserList() ([]*User, error) {
 // UserPost creates a new user account.
 func (c *client) UserPost(in *User) (*User, error) {
 	out := new(User)
-	uri := fmt.Sprintf(pathUsers, c.base)
+	uri := fmt.Sprintf(pathUsers, c.addr)
 	err := c.post(uri, in, out)
 	return out, err
 }
@@ -102,30 +132,22 @@ func (c *client) UserPost(in *User) (*User, error) {
 // UserPatch updates a user account.
 func (c *client) UserPatch(in *User) (*User, error) {
 	out := new(User)
-	uri := fmt.Sprintf(pathUser, c.base, in.Login)
+	uri := fmt.Sprintf(pathUser, c.addr, in.Login)
 	err := c.patch(uri, in, out)
 	return out, err
 }
 
 // UserDel deletes a user account.
 func (c *client) UserDel(login string) error {
-	uri := fmt.Sprintf(pathUser, c.base, login)
+	uri := fmt.Sprintf(pathUser, c.addr, login)
 	err := c.delete(uri)
 	return err
-}
-
-// UserFeed returns the user's activity feed.
-func (c *client) UserFeed() ([]*Activity, error) {
-	var out []*Activity
-	uri := fmt.Sprintf(pathFeed, c.base)
-	err := c.get(uri, &out)
-	return out, err
 }
 
 // Repo returns a repository by name.
 func (c *client) Repo(owner string, name string) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepo, c.base, owner, name)
+	uri := fmt.Sprintf(pathRepo, c.addr, owner, name)
 	err := c.get(uri, out)
 	return out, err
 }
@@ -134,7 +156,7 @@ func (c *client) Repo(owner string, name string) (*Repo, error) {
 // the user has explicit access in the host system.
 func (c *client) RepoList() ([]*Repo, error) {
 	var out []*Repo
-	uri := fmt.Sprintf(pathRepos, c.base)
+	uri := fmt.Sprintf(pathRepos, c.addr)
 	err := c.get(uri, &out)
 	return out, err
 }
@@ -142,22 +164,36 @@ func (c *client) RepoList() ([]*Repo, error) {
 // RepoPost activates a repository.
 func (c *client) RepoPost(owner string, name string) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepo, c.base, owner, name)
+	uri := fmt.Sprintf(pathRepo, c.addr, owner, name)
 	err := c.post(uri, nil, out)
 	return out, err
 }
 
-// RepoPatch updates a repository.
-func (c *client) RepoPatch(in *Repo) (*Repo, error) {
+// RepoChown updates a repository owner.
+func (c *client) RepoChown(owner string, name string) (*Repo, error) {
 	out := new(Repo)
-	uri := fmt.Sprintf(pathRepo, c.base, in.Owner, in.Name)
+	uri := fmt.Sprintf(pathChown, c.addr, owner, name)
+	err := c.post(uri, nil, out)
+	return out, err
+}
+
+// RepoRepair repais the repository hooks.
+func (c *client) RepoRepair(owner string, name string) error {
+	uri := fmt.Sprintf(pathRepair, c.addr, owner, name)
+	return c.post(uri, nil, nil)
+}
+
+// RepoPatch updates a repository.
+func (c *client) RepoPatch(owner, name string, in *RepoPatch) (*Repo, error) {
+	out := new(Repo)
+	uri := fmt.Sprintf(pathRepo, c.addr, owner, name)
 	err := c.patch(uri, in, out)
 	return out, err
 }
 
 // RepoDel deletes a repository.
 func (c *client) RepoDel(owner, name string) error {
-	uri := fmt.Sprintf(pathRepo, c.base, owner, name)
+	uri := fmt.Sprintf(pathRepo, c.addr, owner, name)
 	err := c.delete(uri)
 	return err
 }
@@ -165,7 +201,7 @@ func (c *client) RepoDel(owner, name string) error {
 // Build returns a repository build by number.
 func (c *client) Build(owner, name string, num int) (*Build, error) {
 	out := new(Build)
-	uri := fmt.Sprintf(pathBuild, c.base, owner, name, num)
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, num)
 	err := c.get(uri, out)
 	return out, err
 }
@@ -173,7 +209,7 @@ func (c *client) Build(owner, name string, num int) (*Build, error) {
 // Build returns the latest repository build by branch.
 func (c *client) BuildLast(owner, name, branch string) (*Build, error) {
 	out := new(Build)
-	uri := fmt.Sprintf(pathBuild, c.base, owner, name, "latest")
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, "latest")
 	if len(branch) != 0 {
 		uri += "?branch=" + branch
 	}
@@ -185,103 +221,161 @@ func (c *client) BuildLast(owner, name, branch string) (*Build, error) {
 // the specified repository.
 func (c *client) BuildList(owner, name string) ([]*Build, error) {
 	var out []*Build
-	uri := fmt.Sprintf(pathBuilds, c.base, owner, name)
+	uri := fmt.Sprintf(pathBuilds, c.addr, owner, name)
+	err := c.get(uri, &out)
+	return out, err
+}
+
+// BuildQueue returns a list of enqueued builds.
+func (c *client) BuildQueue() ([]*Activity, error) {
+	var out []*Activity
+	uri := fmt.Sprintf(pathBuildQueue, c.addr)
 	err := c.get(uri, &out)
 	return out, err
 }
 
 // BuildStart re-starts a stopped build.
-func (c *client) BuildStart(owner, name string, num int) (*Build, error) {
+func (c *client) BuildStart(owner, name string, num int, params map[string]string) (*Build, error) {
 	out := new(Build)
-	uri := fmt.Sprintf(pathBuild, c.base, owner, name, num)
-	err := c.post(uri, nil, out)
+	val := mapValues(params)
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, num)
+	err := c.post(uri+"?"+val.Encode(), nil, out)
 	return out, err
 }
 
 // BuildStop cancels the running job.
 func (c *client) BuildStop(owner, name string, num, job int) error {
-	uri := fmt.Sprintf(pathJob, c.base, owner, name, num, job)
+	uri := fmt.Sprintf(pathJob, c.addr, owner, name, num, job)
 	err := c.delete(uri)
 	return err
 }
 
 // BuildFork re-starts a stopped build with a new build number,
 // preserving the prior history.
-func (c *client) BuildFork(owner, name string, num int) (*Build, error) {
+func (c *client) BuildFork(owner, name string, num int, params map[string]string) (*Build, error) {
 	out := new(Build)
-	uri := fmt.Sprintf(pathBuild+"?fork=true", c.base, owner, name, num)
+	val := mapValues(params)
+	val.Set("fork", "true")
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, num)
+	err := c.post(uri+"?"+val.Encode(), nil, out)
+	return out, err
+}
+
+// BuildApprove approves a blocked build.
+func (c *client) BuildApprove(owner, name string, num int) (*Build, error) {
+	out := new(Build)
+	uri := fmt.Sprintf(pathApprove, c.addr, owner, name, num)
 	err := c.post(uri, nil, out)
 	return out, err
+}
+
+// BuildDecline declines a blocked build.
+func (c *client) BuildDecline(owner, name string, num int) (*Build, error) {
+	out := new(Build)
+	uri := fmt.Sprintf(pathDecline, c.addr, owner, name, num)
+	err := c.post(uri, nil, out)
+	return out, err
+}
+
+// BuildKill force kills the running build.
+func (c *client) BuildKill(owner, name string, num int) error {
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, num)
+	err := c.delete(uri)
+	return err
 }
 
 // BuildLogs returns the build logs for the specified job.
 func (c *client) BuildLogs(owner, name string, num, job int) (io.ReadCloser, error) {
-	uri := fmt.Sprintf(pathLog, c.base, owner, name, num, job)
-	return c.stream(uri, "GET", nil, nil)
-}
-
-// BuildQueue returns a list of builds in queue.
-func (c *client) BuildQueue() ([]*Activity, error) {
-	var out []*Activity
-	uri := fmt.Sprintf(pathQueue, c.base)
-	err := c.get(uri, &out)
-	return out, err
+	return nil, errors.New("Method not implemented")
 }
 
 // Deploy triggers a deployment for an existing build using the
 // specified target environment.
-func (c *client) Deploy(owner, name string, num int, env string) (*Build, error) {
+func (c *client) Deploy(owner, name string, num int, env string, params map[string]string) (*Build, error) {
 	out := new(Build)
-	val := url.Values{}
+	val := mapValues(params)
 	val.Set("fork", "true")
 	val.Set("event", "deployment")
 	val.Set("deploy_to", env)
-	uri := fmt.Sprintf(pathBuild+"?"+val.Encode(), c.base, owner, name, num)
-	err := c.post(uri, nil, out)
+	uri := fmt.Sprintf(pathBuild, c.addr, owner, name, num)
+	err := c.post(uri+"?"+val.Encode(), nil, out)
 	return out, err
 }
 
-// SecretPost create or updates a repository secret.
-func (c *client) SecretPost(owner, name string, secret *Secret) error {
-	uri := fmt.Sprintf(pathSecrets, c.base, owner, name)
-	return c.post(uri, secret, nil)
+// Registry returns a registry by hostname.
+func (c *client) Registry(owner, name, hostname string) (*Registry, error) {
+	out := new(Registry)
+	uri := fmt.Sprintf(pathRepoRegistry, c.addr, owner, name, hostname)
+	err := c.get(uri, out)
+	return out, err
 }
 
-// SecretDel deletes a named repository secret.
-func (c *client) SecretDel(owner, name, secret string) error {
-	uri := fmt.Sprintf(pathSecret, c.base, owner, name, secret)
+// RegistryList returns a list of all repository registries.
+func (c *client) RegistryList(owner string, name string) ([]*Registry, error) {
+	var out []*Registry
+	uri := fmt.Sprintf(pathRepoRegistries, c.addr, owner, name)
+	err := c.get(uri, &out)
+	return out, err
+}
+
+// RegistryCreate creates a registry.
+func (c *client) RegistryCreate(owner, name string, in *Registry) (*Registry, error) {
+	out := new(Registry)
+	uri := fmt.Sprintf(pathRepoRegistries, c.addr, owner, name)
+	err := c.post(uri, in, out)
+	return out, err
+}
+
+// RegistryUpdate updates a registry.
+func (c *client) RegistryUpdate(owner, name string, in *Registry) (*Registry, error) {
+	out := new(Registry)
+	uri := fmt.Sprintf(pathRepoRegistry, c.addr, owner, name, in.Address)
+	err := c.patch(uri, in, out)
+	return out, err
+}
+
+// RegistryDelete deletes a registry.
+func (c *client) RegistryDelete(owner, name, hostname string) error {
+	uri := fmt.Sprintf(pathRepoRegistry, c.addr, owner, name, hostname)
 	return c.delete(uri)
 }
 
-// Sign returns a cryptographic signature for the input string.
-func (c *client) Sign(owner, name string, in []byte) ([]byte, error) {
-	buf := bytes.Buffer{}
-	buf.Write(in)
-	uri := fmt.Sprintf(pathSign, c.base, owner, name)
-	rc, err := c.stream(uri, "POST", buf, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer rc.Close()
-	return ioutil.ReadAll(rc)
+// Secret returns a secret by name.
+func (c *client) Secret(owner, name, secret string) (*Secret, error) {
+	out := new(Secret)
+	uri := fmt.Sprintf(pathRepoSecret, c.addr, owner, name, secret)
+	err := c.get(uri, out)
+	return out, err
 }
 
-// Agent returns a build agent by address.
-func (c *client) Agent(addr string) (*Agent, error) {
-	return nil, fmt.Errorf("Not yet implemented")
-}
-
-// AgentDel deletes a build agent by address.
-func (c *client) AgentDel(addr string) error {
-	return fmt.Errorf("Not yet implemented")
-}
-
-// AgentList returns a list of build agents.
-func (c *client) AgentList() ([]*Agent, error) {
-	var out []*Agent
-	uri := fmt.Sprintf(pathAgent, c.base)
+// SecretList returns a list of all repository secrets.
+func (c *client) SecretList(owner string, name string) ([]*Secret, error) {
+	var out []*Secret
+	uri := fmt.Sprintf(pathRepoSecrets, c.addr, owner, name)
 	err := c.get(uri, &out)
 	return out, err
+}
+
+// SecretCreate creates a secret.
+func (c *client) SecretCreate(owner, name string, in *Secret) (*Secret, error) {
+	out := new(Secret)
+	uri := fmt.Sprintf(pathRepoSecrets, c.addr, owner, name)
+	err := c.post(uri, in, out)
+	return out, err
+}
+
+// SecretUpdate updates a secret.
+func (c *client) SecretUpdate(owner, name string, in *Secret) (*Secret, error) {
+	out := new(Secret)
+	uri := fmt.Sprintf(pathRepoSecret, c.addr, owner, name, in.Name)
+	err := c.patch(uri, in, out)
+	return out, err
+}
+
+// SecretDelete deletes a secret.
+func (c *client) SecretDelete(owner, name, secret string) error {
+	uri := fmt.Sprintf(pathRepoSecret, c.addr, owner, name, secret)
+	return c.delete(uri)
 }
 
 //
@@ -308,6 +402,13 @@ func (c *client) patch(rawurl string, in, out interface{}) error {
 	return c.do(rawurl, "PATCH", in, out)
 }
 
+// RepoMove moves a repository
+func (c *client) RepoMove(owner, name, newFullName string) error {
+	uri := fmt.Sprintf(pathRepoMove, c.addr, owner, name, newFullName)
+	return c.post(uri, nil, nil)
+}
+
+
 // helper function for making an http DELETE request.
 func (c *client) delete(rawurl string) error {
 	return c.do(rawurl, "DELETE", nil, nil)
@@ -315,57 +416,38 @@ func (c *client) delete(rawurl string) error {
 
 // helper function to make an http request
 func (c *client) do(rawurl, method string, in, out interface{}) error {
-	// executes the http request and returns the body as
-	// and io.ReadCloser
-	body, err := c.stream(rawurl, method, in, out)
+	body, err := c.open(rawurl, method, in, out)
 	if err != nil {
 		return err
 	}
 	defer body.Close()
-
-	// if a json response is expected, parse and return
-	// the json response.
 	if out != nil {
 		return json.NewDecoder(body).Decode(out)
 	}
 	return nil
 }
 
-// helper function to stream an http request
-func (c *client) stream(rawurl, method string, in, out interface{}) (io.ReadCloser, error) {
+// helper function to open an http request
+func (c *client) open(rawurl, method string, in, out interface{}) (io.ReadCloser, error) {
 	uri, err := url.Parse(rawurl)
 	if err != nil {
 		return nil, err
 	}
-
-	// if we are posting or putting data, we need to
-	// write it to the body of the request.
-	var buf io.ReadWriter
-	if in == nil {
-		// nothing
-	} else if rw, ok := in.(io.ReadWriter); ok {
-		buf = rw
-	} else {
-		buf = new(bytes.Buffer)
-		err := json.NewEncoder(buf).Encode(in)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// creates a new http request to bitbucket.
-	req, err := http.NewRequest(method, uri.String(), buf)
+	req, err := http.NewRequest(method, uri.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	if in == nil {
-		// nothing
-	} else if _, ok := in.(io.ReadWriter); ok {
-		req.Header.Set("Content-Type", "plain/text")
-	} else {
+	if in != nil {
+		decoded, derr := json.Marshal(in)
+		if derr != nil {
+			return nil, derr
+		}
+		buf := bytes.NewBuffer(decoded)
+		req.Body = ioutil.NopCloser(buf)
+		req.ContentLength = int64(len(decoded))
+		req.Header.Set("Content-Length", strconv.Itoa(len(decoded)))
 		req.Header.Set("Content-Type", "application/json")
 	}
-
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -373,7 +455,16 @@ func (c *client) stream(rawurl, method string, in, out interface{}) (io.ReadClos
 	if resp.StatusCode > http.StatusPartialContent {
 		defer resp.Body.Close()
 		out, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf(string(out))
+		return nil, fmt.Errorf("client error %d: %s", resp.StatusCode, string(out))
 	}
 	return resp.Body, nil
+}
+
+// mapValues converts a map to url.Values
+func mapValues(params map[string]string) url.Values {
+	values := url.Values{}
+	for key, val := range params {
+		values.Add(key, val)
+	}
+	return values
 }

--- a/vendor/github.com/drone/drone-go/drone/const.go
+++ b/vendor/github.com/drone/drone-go/drone/const.go
@@ -1,6 +1,6 @@
 package drone
 
-// Events
+// Event values.
 const (
 	EventPush   = "push"
 	EventPull   = "pull_request"
@@ -8,8 +8,9 @@ const (
 	EventDeploy = "deployment"
 )
 
-// Statuses
+// Status values.
 const (
+	StatusBlocked = "blocked"
 	StatusSkipped = "skipped"
 	StatusPending = "pending"
 	StatusRunning = "running"

--- a/vendor/github.com/drone/drone-go/drone/interface.go
+++ b/vendor/github.com/drone/drone-go/drone/interface.go
@@ -1,8 +1,6 @@
 package drone
 
-import "io"
-
-// Client describes a drone client.
+// Client is used to communicate with a Drone server.
 type Client interface {
 	// Self returns the currently authenticated user.
 	Self() (*User, error)
@@ -22,9 +20,6 @@ type Client interface {
 	// UserDel deletes a user account.
 	UserDel(string) error
 
-	// UserFeed returns the user's activity feed.
-	UserFeed() ([]*Activity, error)
-
 	// Repo returns a repository by name.
 	Repo(string, string) (*Repo, error)
 
@@ -36,7 +31,16 @@ type Client interface {
 	RepoPost(string, string) (*Repo, error)
 
 	// RepoPatch updates a repository.
-	RepoPatch(*Repo) (*Repo, error)
+	RepoPatch(string, string, *RepoPatch) (*Repo, error)
+
+	// RepoMove moves the repository
+	RepoMove(string, string, string) error
+
+	// RepoChown updates a repository owner.
+	RepoChown(string, string) (*Repo, error)
+
+	// RepoRepair repairs the repository hooks.
+	RepoRepair(string, string) error
 
 	// RepoDel deletes a repository.
 	RepoDel(string, string) error
@@ -52,41 +56,59 @@ type Client interface {
 	// the specified repository.
 	BuildList(string, string) ([]*Build, error)
 
+	// BuildQueue returns a list of enqueued builds.
+	BuildQueue() ([]*Activity, error)
+
 	// BuildStart re-starts a stopped build.
-	BuildStart(string, string, int) (*Build, error)
+	BuildStart(string, string, int, map[string]string) (*Build, error)
 
 	// BuildStop stops the specified running job for given build.
 	BuildStop(string, string, int, int) error
 
 	// BuildFork re-starts a stopped build with a new build number, preserving
 	// the prior history.
-	BuildFork(string, string, int) (*Build, error)
+	BuildFork(string, string, int, map[string]string) (*Build, error)
 
-	// BuildLogs returns the build logs for the specified job.
-	BuildLogs(string, string, int, int) (io.ReadCloser, error)
+	// BuildApprove approves a blocked build.
+	BuildApprove(string, string, int) (*Build, error)
 
-	// BuildQueue returns a list of builds in queue.
-	BuildQueue() ([]*Activity, error)
+	// BuildDecline declines a blocked build.
+	BuildDecline(string, string, int) (*Build, error)
+
+	// BuildKill force kills the running build.
+	BuildKill(string, string, int) error
 
 	// Deploy triggers a deployment for an existing build using the specified
 	// target environment.
-	Deploy(string, string, int, string) (*Build, error)
+	Deploy(string, string, int, string, map[string]string) (*Build, error)
 
-	// Sign returns a cryptographic signature for the input string.
-	Sign(string, string, []byte) ([]byte, error)
+	// Registry returns a registry by hostname.
+	Registry(owner, name, hostname string) (*Registry, error)
 
-	// SecretPost create or updates a repository secret.
-	SecretPost(string, string, *Secret) error
+	// RegistryList returns a list of all repository registries.
+	RegistryList(owner, name string) ([]*Registry, error)
 
-	// SecretDel deletes a named repository secret.
-	SecretDel(string, string, string) error
+	// RegistryCreate creates a registry.
+	RegistryCreate(owner, name string, registry *Registry) (*Registry, error)
 
-	// Agent returns an agent by IP address.
-	Agent(string) (*Agent, error)
+	// RegistryUpdate updates a registry.
+	RegistryUpdate(owner, name string, registry *Registry) (*Registry, error)
 
-	// AgentDel deletes an agent by IP address.
-	AgentDel(string) error
+	// RegistryDelete deletes a registry.
+	RegistryDelete(owner, name, hostname string) error
 
-	// AgentList returns a list of build agents.
-	AgentList() ([]*Agent, error)
+	// Secret returns a secret by name.
+	Secret(owner, name, secret string) (*Secret, error)
+
+	// SecretList returns a list of all repository secrets.
+	SecretList(owner, name string) ([]*Secret, error)
+
+	// SecretCreate creates a registry.
+	SecretCreate(owner, name string, secret *Secret) (*Secret, error)
+
+	// SecretUpdate updates a registry.
+	SecretUpdate(owner, name string, secret *Secret) (*Secret, error)
+
+	// SecretDelete deletes a secret.
+	SecretDelete(owner, name, secret string) error
 }

--- a/vendor/github.com/drone/drone-go/drone/types.go
+++ b/vendor/github.com/drone/drone-go/drone/types.go
@@ -1,149 +1,142 @@
 package drone
 
-// User represents a user account.
-type User struct {
-	ID     int64  `json:"id"`
-	Login  string `json:"login"`
-	Email  string `json:"email"`
-	Avatar string `json:"avatar_url"`
-	Active bool   `json:"active"`
-	Admin  bool   `json:"admin"`
-}
+type (
+	// User represents a user account.
+	User struct {
+		ID     int64  `json:"id"`
+		Login  string `json:"login"`
+		Email  string `json:"email"`
+		Avatar string `json:"avatar_url"`
+		Active bool   `json:"active"`
+		Admin  bool   `json:"admin"`
+	}
 
-// Repo represents a version control repository.
-type Repo struct {
-	ID          int64  `json:"id"`
-	Owner       string `json:"owner"`
-	Name        string `json:"name"`
-	FullName    string `json:"full_name"`
-	Avatar      string `json:"avatar_url"`
-	Link        string `json:"link_url"`
-	Kind        string `json:"kind"`
-	Clone       string `json:"clone_url"`
-	Branch      string `json:"default_branch"`
-	Timeout     int64  `json:"timeout"`
-	IsPrivate   bool   `json:"private"`
-	IsTrusted   bool   `json:"trusted"`
-	AllowPull   bool   `json:"allow_pr"`
-	AllowPush   bool   `json:"allow_push"`
-	AllowDeploy bool   `json:"allow_deploys"`
-	AllowTag    bool   `json:"allow_tags"`
-}
+	// Repo represents a repository.
+	Repo struct {
+		ID          int64  `json:"id,omitempty"`
+		Owner       string `json:"owner"`
+		Name        string `json:"name"`
+		FullName    string `json:"full_name"`
+		Avatar      string `json:"avatar_url,omitempty"`
+		Link        string `json:"link_url,omitempty"`
+		Kind        string `json:"scm,omitempty"`
+		Clone       string `json:"clone_url,omitempty"`
+		Branch      string `json:"default_branch,omitempty"`
+		Timeout     int64  `json:"timeout,omitempty"`
+		Visibility  string `json:"visibility"`
+		IsPrivate   bool   `json:"private,omitempty"`
+		IsTrusted   bool   `json:"trusted"`
+		IsStarred   bool   `json:"starred,omitempty"`
+		IsGated     bool   `json:"gated"`
+		AllowPull   bool   `json:"allow_pr"`
+		AllowPush   bool   `json:"allow_push"`
+		AllowDeploy bool   `json:"allow_deploys"`
+		AllowTag    bool   `json:"allow_tags"`
+		Config      string `json:"config_file"`
+	}
 
-// Build represents the process of compiling and testing a changeset, typically
-// triggered by the remote system (ie GitHub).
-type Build struct {
-	ID        int64  `json:"id"`
-	Number    int    `json:"number"`
-	Event     string `json:"event"`
-	Status    string `json:"status"`
-	Enqueued  int64  `json:"enqueued_at"`
-	Created   int64  `json:"created_at"`
-	Started   int64  `json:"started_at"`
-	Finished  int64  `json:"finished_at"`
-	Deploy    string `json:"deploy_to"`
-	Commit    string `json:"commit"`
-	Branch    string `json:"branch"`
-	Ref       string `json:"ref"`
-	Refspec   string `json:"refspec"`
-	Remote    string `json:"remote"`
-	Title     string `json:"title"`
-	Message   string `json:"message"`
-	Timestamp int64  `json:"timestamp"`
-	Author    string `json:"author"`
-	Avatar    string `json:"author_avatar"`
-	Email     string `json:"author_email"`
-	Link      string `json:"link_url"`
-	Signed    bool   `json:"signed"`
-	Verified  bool   `json:"verified"`
-}
+	// RepoPatch defines a repository patch request.
+	RepoPatch struct {
+		Config       *string `json:"config_file,omitempty"`
+		IsTrusted    *bool   `json:"trusted,omitempty"`
+		IsGated      *bool   `json:"gated,omitempty"`
+		Timeout      *int64  `json:"timeout,omitempty"`
+		Visibility   *string `json:"visibility"`
+		AllowPull    *bool   `json:"allow_pr,omitempty"`
+		AllowPush    *bool   `json:"allow_push,omitempty"`
+		AllowDeploy  *bool   `json:"allow_deploy,omitempty"`
+		AllowTag     *bool   `json:"allow_tag,omitempty"`
+		BuildCounter *int    `json:"build_counter,omitempty"`
+	}
 
-// Job represents a single job that is being executed as part of a Build.
-type Job struct {
-	ID       int64  `json:"id"`
-	Number   int    `json:"number"`
-	Status   string `json:"status"`
-	Error    string `json:"error"`
-	ExitCode int    `json:"exit_code"`
-	Enqueued int64  `json:"enqueued_at"`
-	Started  int64  `json:"started_at"`
-	Finished int64  `json:"finished_at"`
+	// Build defines a build object.
+	Build struct {
+		ID        int64   `json:"id"`
+		Number    int     `json:"number"`
+		Parent    int     `json:"parent"`
+		Event     string  `json:"event"`
+		Status    string  `json:"status"`
+		Error     string  `json:"error"`
+		Enqueued  int64   `json:"enqueued_at"`
+		Created   int64   `json:"created_at"`
+		Started   int64   `json:"started_at"`
+		Finished  int64   `json:"finished_at"`
+		Deploy    string  `json:"deploy_to"`
+		Commit    string  `json:"commit"`
+		Branch    string  `json:"branch"`
+		Ref       string  `json:"ref"`
+		Refspec   string  `json:"refspec"`
+		Remote    string  `json:"remote"`
+		Title     string  `json:"title"`
+		Message   string  `json:"message"`
+		Timestamp int64   `json:"timestamp"`
+		Sender    string  `json:"sender"`
+		Author    string  `json:"author"`
+		Avatar    string  `json:"author_avatar"`
+		Email     string  `json:"author_email"`
+		Link      string  `json:"link_url"`
+		Reviewer  string  `json:"reviewed_by"`
+		Reviewed  int64   `json:"reviewed_at"`
+		Procs     []*Proc `json:"procs,omitempty"`
+	}
 
-	Environment map[string]string `json:"environment"`
-}
+	// Proc represents a process in the build pipeline.
+	Proc struct {
+		ID       int64             `json:"id"`
+		PID      int               `json:"pid"`
+		PPID     int               `json:"ppid"`
+		PGID     int               `json:"pgid"`
+		Name     string            `json:"name"`
+		State    string            `json:"state"`
+		Error    string            `json:"error,omitempty"`
+		ExitCode int               `json:"exit_code"`
+		Started  int64             `json:"start_time,omitempty"`
+		Stopped  int64             `json:"end_time,omitempty"`
+		Machine  string            `json:"machine,omitempty"`
+		Platform string            `json:"platform,omitempty"`
+		Environ  map[string]string `json:"environ,omitempty"`
+		Children []*Proc           `json:"children,omitempty"`
+	}
 
-// Secret represents a repository secret.
-type Secret struct {
-	ID     int64    `json:"id"`
-	Name   string   `json:"name"`
-	Value  string   `json:"value"`
-	Images []string `json:"image"`
-	Events []string `json:"event"`
-}
+	// Registry represents a docker registry with credentials.
+	Registry struct {
+		ID       int64  `json:"id"`
+		Address  string `json:"address"`
+		Username string `json:"username"`
+		Password string `json:"password,omitempty"`
+		Email    string `json:"email"`
+		Token    string `json:"token"`
+	}
 
-// Activity represents a build activity. It combines the build details with
-// summary Repository information.
-type Activity struct {
-	Owner     string `json:"owner"`
-	Name      string `json:"name"`
-	FullName  string `json:"full_name"`
-	Number    int    `json:"number"`
-	Event     string `json:"event"`
-	Status    string `json:"status"`
-	Enqueued  int64  `json:"enqueued_at"`
-	Created   int64  `json:"created_at"`
-	Started   int64  `json:"started_at"`
-	Finished  int64  `json:"finished_at"`
-	Commit    string `json:"commit"`
-	Branch    string `json:"branch"`
-	Ref       string `json:"ref"`
-	Refspec   string `json:"refspec"`
-	Remote    string `json:"remote"`
-	Title     string `json:"title"`
-	Message   string `json:"message"`
-	Timestamp int64  `json:"timestamp"`
-	Author    string `json:"author"`
-	Avatar    string `json:"author_avatar"`
-	Email     string `json:"author_email"`
-	Link      string `json:"link_url"`
-	Signed    bool   `json:"signed"`
-	Verified  bool   `json:"verified"`
-}
+	// Secret represents a secret variable, such as a password or token.
+	Secret struct {
+		ID     int64    `json:"id"`
+		Name   string   `json:"name"`
+		Value  string   `json:"value,omitempty"`
+		Images []string `json:"image"`
+		Events []string `json:"event"`
+	}
 
-// Netrc defines a default .netrc file that should be injected into the build
-// environment. It will be used to authorize access to https resources, such as
-// git+https clones.
-type Netrc struct {
-	Machine  string `json:"machine"`
-	Login    string `json:"login"`
-	Password string `json:"password"`
-}
-
-// System represents the drone system.
-type System struct {
-	Version string `json:"version"`
-	Link    string `json:"link_url"`
-}
-
-// Agent represents a registered build node.
-type Agent struct {
-	ID       int64  `json:"id"`
-	Address  string `json:"address"`
-	Platform string `json:"platform"`
-	Capacity int    `json:"capacity"`
-	Created  int64  `json:"created_at"`
-	Updated  int64  `json:"updated_at"`
-}
-
-// Payload defines the full payload send to plugins.
-type Payload struct {
-	Yaml      string    `json:"config"`
-	User      *User     `json:"user"`
-	Repo      *Repo     `json:"repo"`
-	Build     *Build    `json:"build"`
-	BuildLast *Build    `json:"build_last"`
-	Job       *Job      `json:"job"`
-	Netrc     *Netrc    `json:"netrc"`
-	System    *System   `json:"system"`
-	Secrets   []*Secret `json:"secrets"`
-}
+	// Activity represents an item in the user's feed or timeline.
+	Activity struct {
+		Owner    string `json:"owner"`
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+		Number   int    `json:"number,omitempty"`
+		Event    string `json:"event,omitempty"`
+		Status   string `json:"status,omitempty"`
+		Created  int64  `json:"created_at,omitempty"`
+		Started  int64  `json:"started_at,omitempty"`
+		Finished int64  `json:"finished_at,omitempty"`
+		Commit   string `json:"commit,omitempty"`
+		Branch   string `json:"branch,omitempty"`
+		Ref      string `json:"ref,omitempty"`
+		Refspec  string `json:"refspec,omitempty"`
+		Remote   string `json:"remote,omitempty"`
+		Title    string `json:"title,omitempty"`
+		Message  string `json:"message,omitempty"`
+		Author   string `json:"author,omitempty"`
+		Avatar   string `json:"author_avatar,omitempty"`
+		Email    string `json:"author_email,omitempty"`
+	}
+)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2015-09-08T20:46:18Z"
 		},
 		{
-			"checksumSHA1": "8t8iVqBt08r4SW7PxrEu4qp7xLQ=",
+			"checksumSHA1": "L9nnuOR5hwcQd86SLBSpt120h6Q=",
 			"path": "github.com/drone/drone-go/drone",
-			"revision": "e34150a175e665a5fa94218fc7ab9986a0bd7732",
-			"revisionTime": "2016-07-28T16:26:28Z"
+			"revision": "7c21c28963a575c08429ca4b72b1d059e64cae9a",
+			"revisionTime": "2017-08-26T23:29:34Z"
 		},
 		{
 			"checksumSHA1": "Ph3AzJaMHZxUdyqWL+Lx3CufxRw=",


### PR DESCRIPTION
Updated `drone-go` to support build parameters, while stopping short of removal of supporting the `fork` parameter. Supports params in KEY=value format as well as loading of params from `godotenv` files.

Example:
```
validate:
  image: plugins/downstream
  server: https://drone.example.com
  params:
    - SOURCE_HASH=${DRONE_COMMIT_HASH}
    - FOO=bar
    - /path/to/godotenv/file
  repositories:
    - octocat/Hello-World
  secrets: [ downstream_token ]
```
I believe this implements the first part of #29.