### PR TITLE
Add deprecation warning for fork option; not supported in 0.8.1 of Drone server

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -26,6 +27,14 @@ func (p *Plugin) Exec() error {
 
 	if len(p.Server) == 0 {
 		return fmt.Errorf("Error: you must provide your Drone server.")
+	}
+
+	if !p.Fork {
+		fmt.Fprintln(
+			os.Stderr,
+			"Warning: \"fork: false\" will be deprecated in future\n"+
+				"         set \"fork: true\" to disable this warning",
+		)
 	}
 
 	client := drone.NewClientToken(p.Server, p.Token)


### PR DESCRIPTION
The `drone-go` client drops support for `BuildFork` in 0.8.1. At some point, this plugin may require a newer version of `drone-go` client that no longer supports `BuildFork`. This message offers users the warning to should set `fork: true` to adhere to the default behavior that newer Drone uses.