### PR TITLE
Add block option to wait for downstream build

### DIFF
--- a/cmd/drone-downstream/config.go
+++ b/cmd/drone-downstream/config.go
@@ -70,5 +70,18 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 			EnvVars:     []string{"PLUGIN_DEPLOY"},
 			Destination: &settings.Deploy,
 		},
+		&cli.BoolFlag{
+			Name:        "block",
+			Usage:       "Block until the triggered build finished, makes this build fail if triggered build fails",
+			EnvVars:     []string{"PLUGIN_BLOCK"},
+			Destination: &settings.Block,
+		},
+		&cli.DurationFlag{
+			Name:        "blockTimeout",
+			Value:       time.Duration(60) * time.Minute,
+			Usage:       "How long to block until the triggered build finished",
+			EnvVars:     []string{"PLUGIN_BLOCK_TIMEOUT"},
+			Destination: &settings.BlockTimeout,
+		},
 	}
 }

--- a/cmd/drone-downstream/config.go
+++ b/cmd/drone-downstream/config.go
@@ -72,14 +72,14 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "block",
-			Usage:       "Block until the triggered build finished, makes this build fail if triggered build fails",
+			Usage:       "Block until the triggered build is finished, makes this build fail if triggered build fails",
 			EnvVars:     []string{"PLUGIN_BLOCK"},
 			Destination: &settings.Block,
 		},
 		&cli.DurationFlag{
 			Name:        "blockTimeout",
 			Value:       time.Duration(60) * time.Minute,
-			Usage:       "How long to block until the triggered build finished",
+			Usage:       "How long to block until the triggered build is finished",
 			EnvVars:     []string{"PLUGIN_BLOCK_TIMEOUT"},
 			Destination: &settings.BlockTimeout,
 		},

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -359,20 +359,18 @@ func blockUntilBuildIsFinished(p *Plugin, client drone.Client, namespace, name s
 				return err
 			}
 
-			s := build.Status
-			if s == drone.StatusError || s == drone.StatusKilled || s == drone.StatusFailing || s == drone.StatusDeclined || s == drone.StatusSkipped {
+			switch build.Status {
+			case drone.StatusError, drone.StatusKilled, drone.StatusFailing, drone.StatusDeclined, drone.StatusSkipped:
 				return fmt.Errorf(
 					"build %d did not succeed: %s",
 					buildNumber,
-					s,
+					build.Status,
 				)
-			}
-
-			if s == drone.StatusPassing {
+			case drone.StatusPassing:
 				return nil
+			default:
+				fmt.Printf("Waiting for build %d in status %s\n", buildNumber, build.Status)
 			}
-
-			fmt.Printf("Waiting for build %d in status %s\n", buildNumber, s)
 		}
 	}
 }

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -322,14 +322,16 @@ func getServerWithDefaults(server string, host string, protocol string) string {
 }
 
 func blockUntilBuildIsFinished(p *Plugin, client drone.Client, namespace, name string, buildNumber int) error {
-	fmt.Printf("\nblocking until triggered build is finished (canceling this build will cancel the downstream build too)\n")
+	fmt.Printf("\nblocking until triggered build is finished\n")
 
 	timeout := time.After(p.settings.BlockTimeout)
 
 	//lint:ignore SA1015 refactor later
 	tick := time.Tick(10 * time.Second)
 
-	// listen for SIGINT and SIGTERM to cancel downstream build when our build is cancelled
+	// listen for SIGINT and SIGTERM to cancel downstream build when stopping this executable
+	// this does not work in drone because drone uses SIGKILL to terminate its containers
+	// but when running the plugin locally during development, it's very handy
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	defer close(sigs)

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -60,6 +60,11 @@ func (p *Plugin) Validate() error {
 		return fmt.Errorf("unable to parse params: %s", err)
 	}
 
+	upstreamBuildNumber, ok := os.LookupEnv("DRONE_BUILD_NUMBER")
+	if ok {
+		p.settings.params["DRONE_UPSTREAM_BUILD_NUMBER"] = upstreamBuildNumber
+	}
+
 	for _, k := range p.settings.ParamsEnv.Value() {
 		v, exists := os.LookupEnv(k)
 		if !exists {


### PR DESCRIPTION
This adds block and blockTimeout options to wait for downstream builds. 

It's not a rewrite of the plugin as #68 suggests, but it achieves one aspect of that issue.